### PR TITLE
Add support for custom url transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Allow you to fix `url()` according to postcss `to` and/or `from` options (rebase
 
 Allow you to inline assets using base64 syntax. Can use postcss `from` option to find ressources.
 
+#### `url: Function`
+
+Custom transform function. Takes one argument (original url) and should return the transformed url.
+
 ##### `maxSize: "size in kbytes"`
 
 Specify the maximum file size to inline

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function fixUrl(options) {
  * @param {Object} decl
  * @param {String} from
  * @param {String} to
- * @param {String} mode
+ * @param {String|Function} mode
  * @param {Object} options
  */
 function processDecl(decl, from, to, mode, options) {
@@ -47,6 +47,10 @@ function processDecl(decl, from, to, mode, options) {
     // save quote style
     var quote = getQuote(value)
     value = unquote(value, quote)
+
+    if (typeof mode === "function") {
+      return processCustom(quote, value, mode);
+    }
 
     // ignore absolute url
     if (value.indexOf("/") === 0) {
@@ -68,6 +72,20 @@ function processDecl(decl, from, to, mode, options) {
     }
   })
 }
+
+
+/**
+ * Transform url() based on a custom callback
+ *
+ * @param {String} quote
+ * @param {String} value
+ * @param {Function} cb
+ */
+function processCustom(quote, value, cb) {
+  var newValue = cb(value)
+  return createUrl(quote, newValue)
+}
+
 
 /**
  * Fix url() according to source (`from`) or destination (`to`)

--- a/test/fixtures/custom.css
+++ b/test/fixtures/custom.css
@@ -1,0 +1,3 @@
+body {
+  background: url("one"), url('two'), url(three), url(four);
+}

--- a/test/fixtures/custom.expected.css
+++ b/test/fixtures/custom.expected.css
@@ -1,0 +1,3 @@
+body {
+  background: url("ONE"), url('TWO'), url(THREE), url(FOUR);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -72,3 +72,10 @@ test("inline", function(t) {
 
   t.end()
 })
+
+test("custom", function(t) {
+  var opts = {url: function(url) { return url.toUpperCase(); }}
+  compareFixtures(t, "custom", "should transform url through custom callback", opts)
+
+  t.end()
+})


### PR DESCRIPTION
My use case for this is re-writing asset urls to their CDN names when I deploy to production.

cc: @MoOx 
