### PR TITLE
Ignore uris

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ function processDecl(decl, from, to, mode, options) {
       return processCustom(quote, value, mode);
     }
 
-    // ignore absolute url
-    if (/^(?:[a-z]+:\/)?\//.test(value)) {
+    // ignore absolute url and uri
+    if (/^(?:[a-z]+:\/|data:.*)?\//.test(value)) {
       return createUrl(quote, value);
     }
 

--- a/test/fixtures/absolute-urls.css
+++ b/test/fixtures/absolute-urls.css
@@ -16,4 +16,6 @@ body {
   background: url(ftp://one);
   background: url(unknown://one);
   background: url(/one);
+
+  background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
 }

--- a/test/fixtures/absolute-urls.expected.css
+++ b/test/fixtures/absolute-urls.expected.css
@@ -16,4 +16,6 @@ body {
   background: url(ftp://one);
   background: url(unknown://one);
   background: url(/one);
+
+  background: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -81,7 +81,7 @@ test("custom", function(t) {
 })
 
 test("absolute-urls", function(t) {
-  compareFixtures(t, "absolute-urls", "shouldn't not transform absolute urls");
+  compareFixtures(t, "absolute-urls", "shouldn't not transform absolute urls or uri");
 
   t.end();
 })


### PR DESCRIPTION
Does fixes things: In the case of `rebase`, it would clobber the consecutive slashes in a data uri. The newly added test case would fail. And, in the case of `inline` it's really annoying to see all the warnings when it's trying to match existing data uris as files.

cc: @MoOx
