### PR TITLE
Fix incorrect base64 output by removing js-base64 dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.2 - 2015-01-08
+
+- Use Node's native buffer.toString("base64")
+  The js-base64 library was producing incorrect base64 for certain files
+
 # 1.2.1 - 2014-12-09
 
 - Data URIs are ignored correctly ([#15](https://github.com/postcss/postcss-url/pull/15))

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
  */
 var fs = require("fs")
 var path = require("path")
-var base64 = require("js-base64").Base64
 var mime = require("mime")
 var reduceFunctionCall = require("reduce-function-call");
 
@@ -144,7 +143,7 @@ function processInline(from, dirname, newPath, quote, value, options) {
     }
     else {
       file = fs.readFileSync(file)
-      newPath = "data:" + mimeType + ";base64," + base64.encode(file)
+      newPath = "data:" + mimeType + ";base64," + file.toString("base64")
     }
   }
   return createUrl(quote, newPath)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-url",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "PostCSS plugin to rebase or inline on url().",
   "keywords": [
     "css",


### PR DESCRIPTION
I found that the js-base64 library would occasionally produce invalid base64 output from my images. The output was valid base64, but the resulting decoded image was invalid. I had trouble with this image in particular:
![test.png](https://cloud.githubusercontent.com/assets/2363700/5668188/a05975be-9722-11e4-8044-c6a9f85ee637.png)

The following is a reproduction of that bug:
```javascript
var fs = require("fs")
var path = require("path")
var base64 = require("js-base64").Base64
var file = fs.readFileSync("test.png")
console.log(base64.encode(file))
// logs incorrect, invalid image: 77+9UE5HDQoaCgAAAA1JSERSAAADDAAAAAEIAwAAAETvv73v...
console.log(file.toString("base64"))
// logs correct, valid image: iVBORw0KGgoAAAANSUhEUgAAAwwAAAABCAMAAABE19kKAA...
```

My pull request uses the native Node file.toString('base64'). This shouldn't affect any portability because, as I understand it, postcss processors are only expected to run in Node, where the Buffer object is always available.

I have not investigated why the js-base64 library has this bug, but eliminating it solves my problem.