### PR TITLE
Ignore urls with fragments/hashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var fs = require("fs")
 var path = require("path")
 var mime = require("mime")
+var url = require("url");
 var reduceFunctionCall = require("reduce-function-call");
 
 /**
@@ -32,7 +33,7 @@ module.exports = function fixUrl(options) {
 }
 
 /**
- * Processes one delcaration
+ * Processes one declaration
  *
  * @param {Object} decl
  * @param {String} from
@@ -53,6 +54,12 @@ function processDecl(decl, from, to, mode, options) {
 
     // ignore absolute urls or data uris
     if (/^(?:[a-z]+:\/|data:.*)?\//.test(value)) {
+      return createUrl(quote, value);
+    }
+
+    // ignore hashes
+    var link = url.parse(value);
+    if (link.hash) {
       return createUrl(quote, value);
     }
 

--- a/test/fixtures/cant-inline-hash.css
+++ b/test/fixtures/cant-inline-hash.css
@@ -1,0 +1,3 @@
+body {
+  clip-path: url("pixel.svg#el")
+}

--- a/test/fixtures/cant-inline-hash.expected.css
+++ b/test/fixtures/cant-inline-hash.expected.css
@@ -1,0 +1,3 @@
+body {
+  clip-path: url("pixel.svg#el")
+}

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,8 @@ test("inline", function(t) {
   var opts = {url: "inline"}
   compareFixtures(t, "cant-inline", "shouldn't inline url if not info available", opts)
 
+  compareFixtures(t, "cant-inline-hash", "shouldn't inline url if it has a hash in it", opts)
+
   t.ok(
     postcss()
       .use(url(opts))


### PR DESCRIPTION
Some url()'s have hashes, ignore them. Example: http://css-tricks.com/svg-fragment-identifiers-work/