### PR TITLE
bugfix:inline fallback function does not work

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ function processInline(from, dirname, urlMeta, to, options, decl) {
 
   function processFallback() {
     if (typeof fallback === "function") {
-      return processCustom(urlMeta, fallback, decl)
+      return processCustom(fallback, from, dirname, urlMeta, to, options, decl)
     }
     switch (fallback) {
     case "copy":

--- a/test/fixtures/inline-fallback-function.css
+++ b/test/fixtures/inline-fallback-function.css
@@ -1,0 +1,3 @@
+body {
+  background: url(pixel.gif);
+}

--- a/test/fixtures/inline-fallback-function.expected.css
+++ b/test/fixtures/inline-fallback-function.expected.css
@@ -1,0 +1,3 @@
+body {
+  background: url(one);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -213,3 +213,17 @@ test("copy-when-inline-fallback", function(t) {
 
   testCopy(t, opts, postcssOpts)
 })
+
+test("function-when-inline-fallback", function(t) {
+  var opts = {
+    url: "inline",
+    maxSize: 0,
+    fallback: function () {
+      return "one"
+    },
+  }
+
+  compareFixtures(t, "inline-fallback-function", "should respect the fallback function", opts, { from: "test/fixtures/index.css" })
+
+  t.end()
+})


### PR DESCRIPTION
It seems that the call of `processCustom` in `processFallback` does not respect the signature