### PR TITLE
Inline fallback query

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,12 +241,13 @@ function processInline(result, from, dirname, urlMeta, to, options, decl) {
     return createUrl(urlMeta)
   }
 
-  var mimeType = mime.lookup(file)
   var stats = fs.statSync(file)
 
   if (stats.size >= maxSize) {
     return processFallback()
   }
+
+  var mimeType = mime.lookup(file)
 
   if (!mimeType) {
     result.warn("Unable to find asset mime-type for " + file, {node: decl})
@@ -295,7 +296,8 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
 
   // remove hash or parameters in the url.
   // e.g., url('glyphicons-halflings-regular.eot?#iefix')
-  var filePath = url.parse(filePathUrl, true).pathname
+  var fileLink = url.parse(filePathUrl, true)
+  var filePath = fileLink.pathname
   var name = path.basename(filePath)
   var useHash = options.useHash || false
 
@@ -319,8 +321,8 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
       .update(contents)
       .digest("hex")
       .substr(0, 16)
-    nameUrl = name + path.extname(filePathUrl)
     name += path.extname(filePath)
+    nameUrl = name + (fileLink.search || "") + (fileLink.hash || "")
   }
   else {
     if (!pathIsAbsolute.posix(from)) {

--- a/index.js
+++ b/index.js
@@ -227,12 +227,12 @@ function processInline(result, from, dirname, urlMeta, to, options, decl) {
   }
 
   if (basePath) {
-    fullFilePath = path.join(basePath, urlMeta.value)
+    fullFilePath = path.join(basePath, link.pathname)
   }
   else {
     fullFilePath = dirname !== from
-      ? dirname + path.sep + urlMeta.value
-      : urlMeta.value
+      ? dirname + path.sep + link.pathname
+      : link.pathname
   }
 
   var file = path.resolve(from, fullFilePath)
@@ -282,7 +282,7 @@ function processInline(result, from, dirname, urlMeta, to, options, decl) {
  */
 function processCopy(result, from, dirname, urlMeta, to, options, decl) {
   if (from === to) {
-    result.warn("Option `to` of postscss is required, ignoring", {node: decl})
+    result.warn("Option `to` of postcss is required, ignoring", {node: decl})
     return createUrl(urlMeta)
   }
   var relativeAssetsPath = (options && options.assetsPath)

--- a/test/fixtures/copy-hash-parameters.css
+++ b/test/fixtures/copy-hash-parameters.css
@@ -1,3 +1,3 @@
 body {
-  clip-path: url("imported/pixel.png?#iefix")
+  clip-path: url("imported/pixel.png?v=1.1#iefix")
 }

--- a/test/fixtures/copy-parameters.css
+++ b/test/fixtures/copy-parameters.css
@@ -1,5 +1,5 @@
 body {
-  clip-path: url("imported/pixel.png?#iefix")
+  clip-path: url("imported/pixel.png?foo=bar")
 }
 
 div {

--- a/test/fixtures/copy-parameters.css
+++ b/test/fixtures/copy-parameters.css
@@ -1,4 +1,8 @@
 body {
+  clip-path: url("imported/pixel.png?#iefix")
+}
+
+header {
   clip-path: url("imported/pixel.png?foo=bar")
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -168,7 +168,9 @@ function testCopy(t, opts, postcssOpts) {
       new RegExp("\"" + assetsPath + "imported\/pixel\.png\""),
     copyPixelGif:
       new RegExp("\"" + assetsPath + "pixel\\.gif\""),
-    copyParamsPixelPng:
+    copyParamsPixelPngHash:
+      new RegExp("\"" + assetsPath + "imported\/pixel\\.png\\?\#iefix\""),
+    copyParamsPixelPngParam:
       new RegExp("\"" + assetsPath + "imported\/pixel\\.png\\?foo=bar\""),
     copyParamsPixelGif:
       new RegExp("\"" + assetsPath + "pixel\\.gif\\#el\""),
@@ -199,7 +201,8 @@ function testCopy(t, opts, postcssOpts) {
 
   t.ok(
     (
-      css.match(patterns.copyParamsPixelPng) &&
+      css.match(patterns.copyParamsPixelPngHash) &&
+      css.match(patterns.copyParamsPixelPngParam) &&
       css.match(patterns.copyParamsPixelGif)
     ),
     "should copy asset from the source (`from`) to the assets destination " +

--- a/test/index.js
+++ b/test/index.js
@@ -175,7 +175,7 @@ function testCopy(t, opts, postcssOpts) {
     copyHashPixel:
       new RegExp("\"" + assetsPath + "[a-z0-9]{16}\\.png\""),
     copyHashParamsPixel:
-      new RegExp("\"" + assetsPath + "[a-z0-9]{16}\\.png\\?\\#iefix\""),
+      new RegExp("\"" + assetsPath + "[a-z0-9]{16}\\.png\\?v=1\\.1\\#iefix\""),
   }
 
   var css = postcss()

--- a/test/index.js
+++ b/test/index.js
@@ -169,7 +169,7 @@ function testCopy(t, opts, postcssOpts) {
     copyPixelGif:
       new RegExp("\"" + assetsPath + "pixel\\.gif\""),
     copyParamsPixelPng:
-      new RegExp("\"" + assetsPath + "imported\/pixel\\.png\\?\#iefix\""),
+      new RegExp("\"" + assetsPath + "imported\/pixel\\.png\\?foo=bar\""),
     copyParamsPixelGif:
       new RegExp("\"" + assetsPath + "pixel\\.gif\\#el\""),
     copyHashPixel:
@@ -270,6 +270,7 @@ test("copy-when-inline-fallback", function(t) {
     url: "inline",
     maxSize: 0,
     fallback: "copy",
+    assetsPath: "assets",
   }
 
   compareFixtures(


### PR DESCRIPTION
I was trying to use cssnext to inline (fallback copy) assets and using the fontawesome font.

The first commit fixes the issue that it was trying to `fs.existsSync()` the file including the querystring, which ofc does not exist so it was not copying assets as expected.

The second commit was when I added `useHash`, because `path.extname` gets confused by dots inside the querystring, so it was adding the wrong extension `.0`.

With these fixes, it should now correctly copy and rename (hash) the filenames of fontawesome.