### PR TITLE
Fix backslashes on Windows (#47)

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,5 +349,9 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
     fs.writeFileSync(absoluteAssetsPath, contents)
   }
 
-  return createUrl(urlMeta, path.join(relativeAssetsPath, nameUrl))
+  var assetPath = path.join(relativeAssetsPath, nameUrl)
+  if (path.sep === "\\") {
+    assetPath = assetPath.replace(/\\/g, "\/")
+  }  
+  return createUrl(urlMeta, assetPath)
 }


### PR DESCRIPTION
This is fixing file path handling on Windows for the {url: "copy"} option.
Replace backslashes in the path with forward slashes so the result is a valid URL.