### PR TITLE
Fix common base path calculation (#35)

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,7 +330,8 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
     }
     relativeAssetsPath = path.join(
       relativeAssetsPath,
-      dirname.replace(new RegExp(from + "[\/]\?"), ""),
+      dirname.replace(new RegExp(from.replace(/[.*+?^${}()|[\]\\]/g,
+                                              "\\$&") + "[\/]\?"), ""),
       path.dirname(urlMeta.value)
     )
     absoluteAssetsPath = path.resolve(to, relativeAssetsPath)


### PR DESCRIPTION
A RegExp is being used to subtract out the base path common to "dirname" and "from", but the "from" path was not being properly escaped for use in a RegExp. See:
https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions