### PR TITLE
Fix #48 - Don't escape spaces in file paths as if they were URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,8 +296,8 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
 
   // remove hash or parameters in the url.
   // e.g., url('glyphicons-halflings-regular.eot?#iefix')
-  var fileLink = url.parse(filePathUrl, true)
-  var filePath = fileLink.pathname
+  var fileLink = url.parse(urlMeta.value)
+  var filePath = path.resolve(dirname, fileLink.pathname)
   var name = path.basename(filePath)
   var useHash = options.useHash || false
 


### PR DESCRIPTION
File paths can have spaces in them, and they should not be escaped as if they were URLs. This changes it so the URL parsing is done on the path from the URL, before it is resolved into a full file path.