### PR TITLE
Fix {url: "copy"} on Windows (#35, #47, #48)

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,5 +350,9 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
     fs.writeFileSync(absoluteAssetsPath, contents)
   }
 
-  return createUrl(urlMeta, path.join(relativeAssetsPath, nameUrl))
+  var assetPath = path.join(relativeAssetsPath, nameUrl)
+  if (path.sep === "\\") {
+    assetPath = assetPath.replace(/\\/g, "\/")
+  }  
+  return createUrl(urlMeta, assetPath)
 }

--- a/index.js
+++ b/index.js
@@ -296,8 +296,8 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
 
   // remove hash or parameters in the url.
   // e.g., url('glyphicons-halflings-regular.eot?#iefix')
-  var fileLink = url.parse(filePathUrl, true)
-  var filePath = fileLink.pathname
+  var fileLink = url.parse(urlMeta.value)
+  var filePath = path.resolve(dirname, fileLink.pathname)
   var name = path.basename(filePath)
   var useHash = options.useHash || false
 

--- a/index.js
+++ b/index.js
@@ -330,7 +330,8 @@ function processCopy(result, from, dirname, urlMeta, to, options, decl) {
     }
     relativeAssetsPath = path.join(
       relativeAssetsPath,
-      dirname.replace(new RegExp(from + "[\/]\?"), ""),
+      dirname.replace(new RegExp(from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+                                 + "[\/]\?"), ""),
       path.dirname(urlMeta.value)
     )
     absoluteAssetsPath = path.resolve(to, relativeAssetsPath)


### PR DESCRIPTION
The three commits in this PR collectively fix the functioning of postcss-url with the {url: "copy"} option when run on Windows.
As a result, this allows npm test to run successfully on Windows.
This PR supersedes #49, #50, and #51. I'll close those.