### PR TITLE
removes dirname involvement into relative AssetsPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,8 +297,6 @@ function processCopy(result, from, dirname, oldUrl, to, options, decl) {
     }
     relativeAssetsPath = path.join(
       relativeAssetsPath,
-      dirname.replace(new RegExp(from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-                                 + "[\/]\?"), ""),
       path.dirname(oldUrl)
     )
     absoluteAssetsPath = path.resolve(to, relativeAssetsPath)
@@ -320,6 +318,6 @@ function processCopy(result, from, dirname, oldUrl, to, options, decl) {
   var assetPath = path.join(relativeAssetsPath, nameUrl)
   if (path.sep === "\\") {
     assetPath = assetPath.replace(/\\/g, "\/")
-  }  
+  }
   return assetPath
 }


### PR DESCRIPTION
https://githubcom/postcss/postcss-url/issues/46
please review and test, especially in combination with `postcss-import`, assetsPath + useHash: false
