### PR TITLE
Add rule to isUrlShouldBeIgnored function to fix urlencoded hash symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,6 +162,7 @@ function getDeclProcessor(result, from, to, cb, options, isCustom) {
 function isUrlShouldBeIgnored(url) {
   return url[0] === "/" ||
     url[0] === "#" ||
+    url.indexOf("%23") === 0 ||
     url.indexOf("data:") === 0 ||
     /^[a-z]+:\/\//.test(url)
 }


### PR DESCRIPTION
This svg is valid, but postcss-url break it with rebase option
https://regex101.com/r/zE5yS7/1

Here is a fix
