### PR TITLE
Switch to an async api

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ function getDeclProcessor(result, from, to, cb, options, isCustom) {
 
   return function(decl) {
     var id = 0 // for async replacements
-    var promise = Promise.resolve()
+    var promises = []
 
     UrlsPatterns.some(function(pattern) {
       if (pattern.test(decl.value)) {
@@ -190,12 +190,12 @@ function getDeclProcessor(result, from, to, cb, options, isCustom) {
             if (newUrl.then) {
               var marker = "::id" + id++
 
-              promise = newUrl.then(function(newUrl) {
+              promises.push(newUrl.then(function(newUrl) {
                 decl.value = decl.value.replace(
                   marker,
                   buildUrl(newUrl)
                 )
-              })
+              }))
 
               return marker
             }
@@ -208,7 +208,7 @@ function getDeclProcessor(result, from, to, cb, options, isCustom) {
       }
     })
 
-    return promise
+    return Promise.all(promises)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,10 @@ module.exports = postcss.plugin(
 
       var cb = getDeclProcessor(result, from, to, callback, options, isCustom)
 
-      styles.walkDecls(cb)
+      return new Promise(function(resolve) {
+        styles.walkDecls(cb)
+        resolve()
+      })
     }
   }
 )

--- a/test/index.js
+++ b/test/index.js
@@ -32,14 +32,14 @@ function testCssResult(t, test, name, msg, opts, postcssOpts, plugin) {
 
 function matchCssResult(t, regExp, name, msg, opts, postcssOpts, plugin) {
   testCssResult(t, function(t, css) {
-    t.ok(css.match(regExp))
+    t.ok(css.match(regExp), "should match: " + regExp)
     t.end()
   }, name, msg, opts, postcssOpts, plugin)
 }
 
 function notMatchCssResult(t, regExp, name, msg, opts, postcssOpts, plugin) {
   testCssResult(t, function(t, css) {
-    t.notOk(css.match(regExp))
+    t.notOk(css.match(regExp), "should not match: " + regExp)
     t.end()
   }, name, msg, opts, postcssOpts, plugin)
 }
@@ -61,7 +61,7 @@ test("rebase", function(t) {
   compareFixtures(
     t,
     "cant-rebase",
-    "shouldn't rebase url if not info available")
+    "shouldn't rebase url if no info available")
   compareFixtures(
     t,
     "rebase-to-from",
@@ -121,7 +121,7 @@ test("inline", function(t) {
   compareFixtures(
     t,
     "cant-inline",
-    "shouldn't inline url if not info available", opts)
+    "shouldn't inline url if no info available", opts)
 
   compareFixtures(
     t,
@@ -212,13 +212,14 @@ test("custom", function(t) {
       if (!declOk) {
         t.ok(decl,
             "should offer postcss decl as second parameter")
-        t.ok(options,
-            "should offer postcss decl as last parameter")
+        t.equal(options, opts,
+            "should offer plugin options as last parameter")
         declOk = true
       }
       return URL.toUpperCase()
     },
   }
+
   compareFixtures(
     t,
     "custom",
@@ -316,7 +317,7 @@ test("copy-without-assetsPath", function(t) {
   compareFixtures(
     t,
     "cant-copy",
-    "shouldn't copy assets if not info available", opts)
+    "shouldn't copy assets if no info available", opts)
 
   var postcssOpts = {
     from: "test/fixtures/index.css",
@@ -334,7 +335,7 @@ test("copy-with-assetsPath", function(t) {
   compareFixtures(
     t,
     "cant-copy",
-    "shouldn't copy assets if not info available", opts)
+    "shouldn't copy assets if no info available", opts)
 
   var postcssOpts = {
     from: "test/fixtures/index.css",
@@ -355,7 +356,7 @@ test("copy-when-inline-fallback", function(t) {
   compareFixtures(
     t,
     "cant-copy",
-    "shouldn't copy assets if not info available", opts)
+    "shouldn't copy assets if no info available", opts)
 
   var postcssOpts = {
     from: "test/fixtures/index.css",

--- a/test/index.js
+++ b/test/index.js
@@ -207,6 +207,7 @@ test("inline", function(t) {
 
 test("custom", function(t) {
   var declOk = false
+  var unTouchedUrlsRegExp = /url\([^A-Z\)]+\)/
   var opts = {
     url: function(URL, decl, from, dirname, to, options) {
       if (!declOk) {
@@ -224,6 +225,50 @@ test("custom", function(t) {
     t,
     "custom",
     "should transform url through custom callback", opts)
+
+  matchCssResult(
+    t,
+    unTouchedUrlsRegExp,
+    "custom",
+    "should fallback to an old url, if custom callback returns bad url ", {
+      url: function() {
+        return ""
+      },
+    })
+
+  compareFixtures(
+    t,
+    "custom",
+    "should support promises for custom url callback", {
+      url: function(URL) {
+        return new Promise(function(resolve) {
+          setTimeout(function() {
+            resolve(URL.toUpperCase())
+          }, 100)
+        })
+      },
+    })
+
+  matchCssResult(
+    t,
+    unTouchedUrlsRegExp,
+    "custom",
+    "should fallback to an old url if custom callback promise was rejected", {
+      url: function() {
+        return Promise.reject()
+      },
+    })
+
+  matchCssResult(
+    t,
+    unTouchedUrlsRegExp,
+    "custom",
+    "should fallback to an old url"
+    + "if custom callback promise was resolved with bad url", {
+      url: function() {
+        return Promise.resolve("")
+      },
+    })
 
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -230,7 +230,7 @@ test("custom", function(t) {
     t,
     unTouchedUrlsRegExp,
     "custom",
-    "should fallback to an old url, if custom callback returns bad url ", {
+    "should fallback to an old url, if custom callback returns bad url", {
       url: function() {
         return ""
       },
@@ -240,11 +240,16 @@ test("custom", function(t) {
     t,
     "custom",
     "should support promises for custom url callback", {
-      url: function(URL) {
+      url: function url(URL) {
+        // using index to make first url the being processed
+        // to test, that all the promises are handled
+        var index = url.index || 5
+        url.index = index - 1
+
         return new Promise(function(resolve) {
           setTimeout(function() {
             resolve(URL.toUpperCase())
-          }, 100)
+          }, index)
         })
       },
     })


### PR DESCRIPTION
refs #43

It was a mistake to say, that everything will fit in `fixUrl` :)

Nevertheless, I have finished with some draft implementation! And successfully tested it on my project. But there are, probably, quite a lot of changes...

I can reduce the amount of code, but I have some questions:
- according to the old logic `valueCallback` will return `oldUrl` in two cases: when the url should not be processed (`isUrlShouldBeIgnored`) and when `UrlProcessor` returned an empty url. Is the second case expected behavior or it is a bug? For now I've leaved this logic as it is and added warning for the case, when `UrlProcessor` returns bad value.
- For the flow with promises, I need to do two `String.replace` calls per url. I think, that this extra call is not expensive, but I can be wrong. So I've wrote separate code for sync and async replacements for now. If it is ok, I can wrap all `UrlProcessor` results in Promises and drop sync logic to reduce the amount of code.

And another one question: should I polyfill Promise for an old Node.js?
