### PR TITLE
relative path evaluation improved

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,6 +272,33 @@ function processInline(result, from, dirname, oldUrl, to, options, decl) {
 }
 
 /**
+ * Given a source directory and a target filename, return the relative
+ * file path from source to target.
+ * @param source {String} directory path to start from for traversal
+ * @param target {String} directory path and filename to seek from source
+ * @return Relative path (e.g. "../../style.css") as {String}
+ *
+ * Credits: https://gist.github.com/eriwen/1211656
+ */
+function getRelativePath(source, target) {
+  var sep = (source.indexOf("/") !== -1) ? "/" : "\\",
+    targetArr = target.split(sep),
+    sourceArr = source.split(sep),
+    targetPath = targetArr.join(sep),
+    relativePath = "";
+
+  while (targetPath.indexOf(sourceArr.join(sep)) === -1) {
+    sourceArr.pop();
+    relativePath += ".." + sep;
+  }
+
+  var relPathArr = targetArr.slice(sourceArr.length);
+  relPathArr.length && (relativePath += relPathArr.join(sep) + sep);
+
+  return relativePath;
+}
+
+/**
  * Copy images from readed from url() to an specific assets destination
  * (`assetsPath`) and fix url() according to that path.
  * You can rename the assets by a hash or keep the real filename.
@@ -329,8 +356,7 @@ function processCopy(result, from, dirname, oldUrl, to, options, decl) {
     }
     relativeAssetsPath = path.join(
       relativeAssetsPath,
-      dirname.replace(new RegExp(from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-                                 + "[\/]\?"), ""),
+      getRelativePath(from, dirname),
       path.dirname(oldUrl)
     )
     absoluteAssetsPath = path.resolve(to, relativeAssetsPath)

--- a/index.js
+++ b/index.js
@@ -281,11 +281,11 @@ function processInline(result, from, dirname, oldUrl, to, options, decl) {
  * Credits: https://gist.github.com/eriwen/1211656
  */
 function getRelativePath(source, target) {
-  var sep = (source.indexOf("/") !== -1) ? "/" : "\\",
-    targetArr = target.split(sep),
-    sourceArr = source.split(sep),
-    targetPath = targetArr.join(sep),
-    relativePath = "";
+  var sep = (source.indexOf("/") !== -1) ? "/" : "\\";
+  var targetArr = target.split(sep);
+  var sourceArr = source.split(sep);
+  var targetPath = targetArr.join(sep);
+  var relativePath = "";
 
   while (targetPath.indexOf(sourceArr.join(sep)) === -1) {
     sourceArr.pop();

--- a/test/fixtures/nested/copy.css
+++ b/test/fixtures/nested/copy.css
@@ -1,0 +1,1 @@
+@import '../copy.css';

--- a/test/fixtures/nested/copy.expected.css
+++ b/test/fixtures/nested/copy.expected.css
@@ -1,0 +1,7 @@
+body {
+  clip-path: url("assets/imported/pixel.png")
+}
+
+div {
+  clip-path: url("assets/pixel.gif")
+}

--- a/test/index.js
+++ b/test/index.js
@@ -346,6 +346,66 @@ test("copy-when-inline-fallback", function(t) {
   testCopy(t, opts, postcssOpts)
 })
 
+function removeFile(filename) {
+  try {
+    fs.unlinkSync(filename);
+  }
+  catch(e) {
+    // ignore file does not exist
+    if (e.toString().indexOf('ENOENT') < 0) {
+      throw e;
+    }
+  }
+}
+
+function fileExists(filename) {
+  try {
+    fs.statSync(filename);
+    return true;
+  }
+  catch(e) {
+    // ignore file does not exist
+    if (e.toString().indexOf('ENOENT') < 0) {
+      throw e;
+    }
+    return false;
+  }
+}
+
+function testFileExists(t, filename) {
+  t.ok(
+    fileExists(filename),
+    'file ' + filename + ' should exist'
+  );
+}
+
+test("copy-nested-with-assetsPath", function(t) {
+  removeFile('test/fixtures/build/assets/pixel.gif');
+  removeFile('test/fixtures/build/assets/imported/pixel.png');
+  var opts = {
+    url: "copy",
+    assetsPath: "assets/nested",
+  }
+  var postcssOpts = {
+    from: "test/fixtures/nested/index.css",
+    to: "test/fixtures/build/index.css",
+  }
+
+  compareFixtures(
+    t,
+    "nested/copy",
+    "should copy assets from relative path starting with ../",
+    opts,
+    postcssOpts,
+    require("postcss-import")
+  );
+
+  testFileExists(t, 'test/fixtures/build/assets/pixel.gif');
+  testFileExists(t, 'test/fixtures/build/assets/imported/pixel.png');
+
+  t.end();
+})
+
 test("function-when-inline-fallback", function(t) {
   var opts = {
     url: "inline",


### PR DESCRIPTION
When css files import css files from base or sibling directories (and are processed with postcss-import before postcss-url) the evaluation of relative paths fails.