### PR TITLE
add dependency message support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const postcss = require('postcss');
 
 const paths = require('./lib/paths');
 
+const getPathDeclFile = paths.getPathDeclFile;
 const getDirDeclFile = paths.getDirDeclFile;
 const prepareAsset = paths.prepareAsset;
 const isUrlShouldBeIgnored = paths.isUrlShouldBeIgnored;
@@ -74,8 +75,13 @@ const replaceUrl = (url, dir, options, result, decl) => {
     const mode = isFunction ? 'custom' : (matchedOptions.url || 'rebase');
     const urlProcessor = getUrlProcessor(mode);
     const warn = (message) => decl.warn(result, message);
+    const addDependency = (file) => result.messages.push({
+        type: 'dependency',
+        file,
+        parent: getPathDeclFile(decl)
+    });
 
-    return urlProcessor(asset, dir, matchedOptions, decl, warn, result);
+    return urlProcessor(asset, dir, matchedOptions, decl, warn, result, addDependency);
 };
 
 /**

--- a/src/type/copy.js
+++ b/src/type/copy.js
@@ -26,12 +26,14 @@ const getHashName = (file, options) =>
  * @param {PostcssUrl~Asset} asset
  * @param {PostcssUrl~Dir} dir
  * @param {PostcssUrl~Option} options
- * @param {PostscssUrl~Decl} decl
+ * @param {PostcssUrl~Decl} decl
  * @param {Function} warn
+ * @param {Result} result
+ * @param {Function} addDependency
  *
  * @returns {String|Undefined}
  */
-module.exports = function processCopy(asset, dir, options, decl, warn) {
+module.exports = function processCopy(asset, dir, options, decl, warn, result, addDependency) {
     if (!options.assetsPath && dir.from === dir.to) {
         warn('Option `to` of postcss is required, ignoring');
 
@@ -58,6 +60,8 @@ module.exports = function processCopy(asset, dir, options, decl, warn) {
     if (!fs.existsSync(newAssetPath)) {
         fs.writeFileSync(newAssetPath, file.contents);
     }
+
+    addDependency(file.path);
 
     return `${newRelativeAssetPath}${asset.search}${asset.hash}`;
 };

--- a/src/type/inline.js
+++ b/src/type/inline.js
@@ -35,10 +35,12 @@ function processFallback(originUrl, dir, options) {
  * @param {PostcssUrl~Options} options
  * @param {PostcssUrl~Decl} decl
  * @param {Function} warn
+ * @param {Result} result
+ * @param {Function} addDependency
  *
  * @returns {String|Undefined}
  */
-module.exports = function(asset, dir, options, decl, warn) {
+module.exports = function(asset, dir, options, decl, warn, result, addDependency) {
     const file = getFile(asset, options, dir, warn);
 
     if (!file) return;
@@ -68,6 +70,8 @@ module.exports = function(asset, dir, options, decl, warn) {
         // eslint-disable-next-line max-len
         warn(`Image type is svg and link contains #. Postcss-url cant handle svg fragments. SVG file fully inlined. ${file.path}`);
     }
+
+    addDependency(file.path);
 
     const encodedStr = encodeFile(file, encodeType);
 

--- a/test/misc/messages.js
+++ b/test/misc/messages.js
@@ -1,0 +1,57 @@
+const path = require('path');
+
+describe('misc', () => {
+    it('should add dependency messages with copy', () => {
+        return postcss()
+      .use(postcssUrl({
+          url: 'copy',
+          assetsPath: 'test/fixtures/build/assets'
+      }))
+      .process(read('fixtures/copy'), {
+          from: 'test/fixtures/copy.css'
+      })
+      .then((result) => {
+          const dependencies = result.messages.filter((m) => m.type === 'dependency');
+
+          assert.deepEqual(dependencies, [
+            {
+              type: 'dependency',
+              file: path.resolve('test/fixtures/imported/pixel.png'),
+              parent: path.resolve('test/fixtures/copy.css'),
+            },
+            {
+              type: 'dependency',
+              file: path.resolve('test/fixtures/pixel.gif'),
+              parent: path.resolve('test/fixtures/copy.css'),
+            }
+          ]);
+      });
+    });
+
+    it('should add dependency messages with inline', () => {
+        return postcss()
+      .use(postcssUrl({
+          url: 'inline',
+          assetsPath: 'test/fixtures/build/assets'
+      }))
+      .process(read('fixtures/copy'), {
+          from: 'test/fixtures/copy.css'
+      })
+      .then((result) => {
+          const dependencies = result.messages.filter((m) => m.type === 'dependency');
+
+          assert.deepEqual(dependencies, [
+            {
+              type: 'dependency',
+              file: path.resolve('test/fixtures/imported/pixel.png'),
+              parent: path.resolve('test/fixtures/copy.css'),
+            },
+            {
+              type: 'dependency',
+              file: path.resolve('test/fixtures/pixel.gif'),
+              parent: path.resolve('test/fixtures/copy.css'),
+            }
+          ]);
+      });
+    });
+});


### PR DESCRIPTION
This adds support for postcss's dependency messaging and allows postcss runners that support file watching to account for any inlined or copied files.