### PR TITLE
add option to include fragment identifiers on inline data URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Checkout [tests](test) for examples.
 * `inline`
   * `basePath` - path or array of paths to search assets (relative to `from`, or absolute)
   * `encodeType` - `base64`, `encodeURI`, `encodeURIComponent`
+  * `includeUriFragment` - include the fragment identifer at the end of the URI
   * `maxSize` - file size in kbytes
   * `fallback` - `copy` or custom function for files > `maxSize`
 * `copy`
@@ -187,6 +188,12 @@ A regular expression e.g. `/\.svg$/`, a [minimatch string](https://github.com/is
 
 The url fallback method to use if max size is exceeded or url contains a hash.
 Custom transform functions are supported.
+
+#### `includeUriFragment`
+_(default: `false`)_
+
+Specifies whether the URL's fragment identifer value, if present, will be added
+to the inlined data URI.
 
 #### `basePath`
 

--- a/src/type/inline.js
+++ b/src/type/inline.js
@@ -75,5 +75,5 @@ module.exports = function(asset, dir, options, decl, warn, result, addDependency
 
     const encodedStr = encodeFile(file, encodeType);
 
-    return asset.hash ? encodedStr + asset.hash : encodedStr;
+    return (options.includeUriFragment && asset.hash) ? encodedStr + asset.hash : encodedStr;
 };

--- a/test/fixtures/can-inline-hash-include.css
+++ b/test/fixtures/can-inline-hash-include.css
@@ -1,0 +1,3 @@
+body {
+  clip-path: url("pixel.svg#el")
+}

--- a/test/fixtures/can-inline-hash-include.expected.css
+++ b/test/fixtures/can-inline-hash-include.expected.css
@@ -1,0 +1,3 @@
+body {
+  clip-path: url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E#el")
+}

--- a/test/fixtures/can-inline-hash.expected.css
+++ b/test/fixtures/can-inline-hash.expected.css
@@ -1,3 +1,3 @@
 body {
-  clip-path: url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E#el")
+  clip-path: url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E")
 }

--- a/test/type/inline.js
+++ b/test/type/inline.js
@@ -11,8 +11,15 @@ describe('inline', () => {
     );
 
     compareFixtures(
+        'can-inline-hash-include',
+        'should inline url and include hash, if it has a hash in it and option is enabled',
+        { url: 'inline', encodeType: 'encodeURIComponent', includeUriFragment: true },
+        postcssOpts
+    );
+
+    compareFixtures(
         'can-inline-hash',
-        'should inline url if it has a hash in it',
+        'should inline url and not include hash, if it has a hash in it',
         { url: 'inline', encodeType: 'encodeURIComponent' },
         postcssOpts
     );


### PR DESCRIPTION
A data URI containing a fragment identifier (_hash_) is only fully support in Firefox.  Both webkit and blink based browsers do not support the usage.  See here for additional details: https://bugs.chromium.org/p/chromium/issues/detail?id=123004

This adds an additional `inline` action option to control the addition of the fragment identifier.  It is disabled by default due it its unsupported nature in most browsers.

**Note:** This is a breaking change.