### PR TITLE
support ignoring SVG fragment inlining warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Checkout [tests](test) for examples.
   * `encodeType` - `base64`, `encodeURI`, `encodeURIComponent`
   * `maxSize` - file size in kbytes
   * `fallback` - `copy` or custom function for files > `maxSize`
+  * `ignoreFragmentWarning` - do not warn when an SVG URL with a fragment is inlined
 * `copy`
     * `basePath` - path or array of paths to search assets (relative to `from`, or absolute)
     * `assetsPath` - directory to copy assets (relative to `to` or absolute)
@@ -178,6 +179,14 @@ You can use this option to adjust urls for CDN.
 _(default: `14`)_
 
 Specify the maximum file size to inline (in kbytes)
+
+#### `ignoreFragmentWarning`
+_(default: `false`)_
+
+Do not warn when an SVG URL with a fragment is inlined.
+PostCSS-URL does not support partial inlining.  The entire SVG file will be inlined.  By default a warning will be issued when this occurs.
+
+**NOTE:** Only files less than the maximum size will be inlined.
 
 #### `filter`
 

--- a/src/type/inline.js
+++ b/src/type/inline.js
@@ -66,7 +66,7 @@ module.exports = function(asset, dir, options, decl, warn, result, addDependency
     const encodeType = options.encodeType || defaultEncodeType;
 
     // Warn for svg with hashes/fragments
-    if (isSvg && asset.hash) {
+    if (isSvg && asset.hash && !options.ignoreFragmentWarning) {
         // eslint-disable-next-line max-len
         warn(`Image type is svg and link contains #. Postcss-url cant handle svg fragments. SVG file fully inlined. ${file.path}`);
     }


### PR DESCRIPTION
Adds an `inline` action option to ignore the SVG fragment warning.
When the `maxSize` option is used, some users may wish to avoid the warnings.