### PR TITLE
Fix wrong encoding

### DIFF
--- a/src/type/inline.js
+++ b/src/type/inline.js
@@ -82,6 +82,6 @@ module.exports = function(asset, dir, options, decl, warn, result, addDependency
         ? encodedStr + asset.hash
         : encodedStr;
 
-    // wrap url by quotes if optimized svg
-    return optimizeSvgEncode ? `"${resultValue}"` : resultValue;
+    // wrap url by quotes if percent-encoded svg
+    return isSvg && encodeType !== 'base64' ? `"${resultValue}"` : resultValue;
 };

--- a/test/fixtures/inline-svg-with-parens.css
+++ b/test/fixtures/inline-svg-with-parens.css
@@ -1,0 +1,5 @@
+body {
+  background: url(svg-with-parens.svg);
+  background: url('svg-with-parens.svg');
+  background: url("svg-with-parens.svg");
+}

--- a/test/fixtures/inline-svg-with-parens.expected.css
+++ b/test/fixtures/inline-svg-with-parens.expected.css
@@ -1,0 +1,5 @@
+body {
+  background: url("data:image/svg+xml,%3Csvg%3E%3Cg transform%3D%22translate(0)%22%2F%3E%3C%2Fsvg%3E");
+  background: url("data:image/svg+xml,%3Csvg%3E%3Cg transform%3D%22translate(0)%22%2F%3E%3C%2Fsvg%3E");
+  background: url("data:image/svg+xml,%3Csvg%3E%3Cg transform%3D%22translate(0)%22%2F%3E%3C%2Fsvg%3E");
+}

--- a/test/fixtures/svg-with-parens.svg
+++ b/test/fixtures/svg-with-parens.svg
@@ -1,0 +1,1 @@
+<svg><g transform="translate(0)"/></svg>

--- a/test/type/inline.js
+++ b/test/type/inline.js
@@ -57,6 +57,13 @@ describe('inline', () => {
         postcssOpts
     );
 
+    compareFixtures(
+        'inline-svg-with-parens',
+        'should inline svg wrapped by quotes',
+        { url: 'inline' },
+        postcssOpts
+    );
+
     it('should inline url of imported files', () => {
         postcss()
             .use(require('postcss-import')())


### PR DESCRIPTION
### Problem
`(` and `)` are not encoded in default SVG encoding mode(encodeURIComponent).
This cause error in CSS.

wrong output example:
```css
body {
  background: url(data:image/svg+xml,%3Csvg%3E%3Cg transform%3D%22translate(0)%22%2F%3E%3C%2Fsvg%3E);
}
```
### Solution
Wrap url by quotes.

This PR solves #78.