### PR TITLE
Add option to prepend ./ to rebased urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Checkout [tests](test) for examples.
 ### Options combinations
 
 * `rebase` - _default_
+  * `relative` - prepend a `./` in front of rebased path
 * `inline`
   * `basePath` - path or array of paths to search assets (relative to `from`, or absolute)
   * `encodeType` - `base64`, `encodeURI`, `encodeURIComponent`
@@ -180,6 +181,11 @@ Custom transform function. Takes following arguments:
 
 And should return the transformed url.
 You can use this option to adjust urls for CDN.
+
+#### `relative`
+_(default: `false`)_
+
+Specifies if a `./` should be prepended to rebased path.
 
 #### `maxSize`
 _(default: `14`)_

--- a/src/type/rebase.js
+++ b/src/type/rebase.js
@@ -9,13 +9,15 @@ const normalize = require('../lib/paths').normalize;
  * @type {PostcssUrl~UrlProcessor}
  * @param {PostcssUrl~Asset} asset
  * @param {PostcssUrl~Dir} dir
+ * @param {PostcssUrl~Option} options
  *
  * @returns {String|Undefined}
  */
-module.exports = function(asset, dir) {
+module.exports = function(asset, dir, options) {
     const rebasedUrl = normalize(
         path.relative(dir.to, asset.absolutePath)
     );
+    const relative = options.relative ? './' : '';
 
-    return `${rebasedUrl}${asset.search}${asset.hash}`;
+    return `${relative}${rebasedUrl}${asset.search}${asset.hash}`;
 };


### PR DESCRIPTION
This adds a `relative` option allowing to prepend `./` in front of the rebased URL.

This is needed to rebase paths after `postcss-import` and keep the imports relative to the root `style.css`.

This allows the following structure to work:

```
src/styles
├── index.css
└── webfonts
    ├── opensans
    │   ├── index.css
    │   └── open-sans-v14-latin-regular.woff2
    └── unineue
        ├── index.css
        └── UniNeueLight.woff2
```

> `src/styles/index.css`

```css
@import "./webfonts/opensans";
@import "./webfonts/unineue";

...
```

> `src/styles/webfonts/opensans/index.css`

```css
@font-face {
  font-family: "Open Sans";
  font-style: normal;
  font-weight: normal;
  src: url("./open-sans-v14-latin-regular.eot");

...
```

Using postcss with the following configuration:

> `webpack.config.js`

```js
...
      {
        test: /\.css$/,
        use: [
          require.resolve('style-loader'),
          {
            loader: require.resolve('css-loader'),
            options: {
              importLoaders: 1,
              modules: 1,
            },
          },
          {
            loader: require.resolve('postcss-loader'),
            options: {
              ident: 'postcss',
              plugins: () => [
                require('postcss-import'),
                require('postcss-url')({ relative: true }),
              ],
            },
          },
        ],
      },
...
```