### PR TITLE
prepend original filename in hashed filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ Hash method `xxhash32|xxhash64` or custom function (accept file buffer)
 _(default: `8`)_
 
 Result hash shrink count
+##### `append`
+
+_(default: `false`)_
+
+Prepend the original filename in resulting filename
 
 ---
 

--- a/src/lib/hash.js
+++ b/src/lib/hash.js
@@ -6,7 +6,8 @@ const HEXBASE = 16;
 
 const defaultHashOptions = {
     method: 'xxhash32',
-    shrink: 8
+    shrink: 8,
+    append: false
 };
 
 const getxxhash = (content, options) => {
@@ -20,11 +21,11 @@ const getxxhash = (content, options) => {
 };
 
 const getHash = (content, options) => {
-    if (typeof options.method === 'function') {
+    if (options.method && typeof options.method === 'function') {
         return options.method(content);
     }
 
-    if (options.method.indexOf('xxhash') === 0) {
+    if (options.method && options.method.indexOf('xxhash') === 0) {
         return getxxhash(content, options);
     }
 

--- a/src/type/copy.js
+++ b/src/type/copy.js
@@ -13,7 +13,9 @@ const getAssetsPath = paths.getAssetsPath;
 const normalize = paths.normalize;
 
 const getHashName = (file, options) =>
-    calcHash(file.contents, options) + path.extname(file.path);
+    (options && options.append ? (path.basename(file.path, path.extname(file.path)) + '_') : '')
+     + calcHash(file.contents, options)
+     + path.extname(file.path);
 
 /**
  * Copy images from readed from url() to an specific assets destination

--- a/test/type/copy.js
+++ b/test/type/copy.js
@@ -74,6 +74,7 @@ describe('copy when inline fallback', () => {
 
 function testCopy(opts, postcssOpts) {
     const optsWithHash = Object.assign({}, opts, { useHash: true });
+    const optsWithAppendHash = Object.assign({}, opts, { useHash: true, hashOptions: { append: true } });
     const assetsPath = opts.assetsPath ? `${opts.assetsPath}\/` : '';
     const patterns = {
         copyPixelPng: new RegExp(`"${assetsPath}imported\/pixel\.png"`),
@@ -82,7 +83,8 @@ function testCopy(opts, postcssOpts) {
         copyParamsPixelPngParam: new RegExp(`"${assetsPath}imported\/pixel\\.png\\?foo=bar"`),
         copyParamsPixelGif: new RegExp(`"${assetsPath}pixel\\.gif\\#el"`),
         copyXXHashPixel8: new RegExp(`"${assetsPath}[a-z0-9]{8}\\.png"`),
-        copyXXHashParamsPixel8: new RegExp(`"${assetsPath}[a-z0-9]{8}\\.png\\?v=1\\.1\\#iefix"`)
+        copyXXHashParamsPixel8: new RegExp(`"${assetsPath}[a-z0-9]{8}\\.png\\?v=1\\.1\\#iefix"`),
+        copyXXHashPrependPixel8: new RegExp(`"${assetsPath}pixel_[a-z0-9]{8}\\.png"`)
     };
     const matchAll = (css, patternsKeys) =>
         assert.ok(patternsKeys.every((pat) => css.match(patterns[pat])));
@@ -122,6 +124,16 @@ function testCopy(opts, postcssOpts) {
             );
 
             matchAll(css, ['copyXXHashParamsPixel8']);
+        });
+
+        it('rebase the url using a hash and prepending the original filename', () => {
+            const css = processedCss(
+                'fixtures/copy-hash',
+                optsWithAppendHash,
+                postcssOpts
+            );
+
+            matchAll(css, ['copyXXHashPrependPixel8']);
         });
     });
 }


### PR DESCRIPTION
useful for later referencing of images (so one can map the compiled images to the original ones)

to activate it simply use this `hashOptions`config:

```js
{
  append: true
}
```