### PR TITLE
Skip URLs starting with tilde

### DIFF
--- a/src/lib/decl-processor.js
+++ b/src/lib/decl-processor.js
@@ -19,7 +19,7 @@ const prepareAsset = paths.prepareAsset;
  * @type {UrlRegExp[]}
  */
 const URL_PATTERNS = [
-    /(url\(\s*['"]?)(?!~)([^"')]+)(["']?\s*\))/g,
+    /(url\(\s*['"]?)([^"')]+)(["']?\s*\))/g,
     /(AlphaImageLoader\(\s*src=['"]?)([^"')]+)(["'])/g
 ];
 

--- a/src/lib/decl-processor.js
+++ b/src/lib/decl-processor.js
@@ -19,7 +19,7 @@ const prepareAsset = paths.prepareAsset;
  * @type {UrlRegExp[]}
  */
 const URL_PATTERNS = [
-    /(url\(\s*['"]?)([^"')]+)(["']?\s*\))/g,
+    /(url\(\s*['"]?)(?!~)([^"')]+)(["']?\s*\))/g,
     /(AlphaImageLoader\(\s*src=['"]?)([^"')]+)(["'])/g
 ];
 

--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -35,7 +35,10 @@ const isUrlWithoutPathname = (assetUrl) => {
  * @returns {Boolean}
  */
 const isUrlShouldBeIgnored = (assetUrl, options) => {
-    return isUrlWithoutPathname(assetUrl) || (assetUrl[0] === '/' && !options.basePath);
+    const isAbsolutePath = assetUrl[0] === '/';
+    const isStartsWithTilde = assetUrl[0] === '~';
+
+    return isUrlWithoutPathname(assetUrl) || ((isAbsolutePath || isStartsWithTilde) && !options.basePath);
 };
 
 /**

--- a/src/type/copy.js
+++ b/src/type/copy.js
@@ -13,7 +13,7 @@ const getAssetsPath = paths.getAssetsPath;
 const normalize = paths.normalize;
 
 const getHashName = (file, options) =>
-    (options && options.append ? (path.basename(file.path, path.extname(file.path)) + '_') : '')
+    (options && options.append ? (`${path.basename(file.path, path.extname(file.path))}_`) : '')
      + calcHash(file.contents, options)
      + path.extname(file.path);
 

--- a/test/fixtures/skip-urls-with-tilde.css
+++ b/test/fixtures/skip-urls-with-tilde.css
@@ -1,0 +1,3 @@
+body {
+  background: url("~one"), url("~./two"), url("~@three"), url("~@four/qwe");
+}

--- a/test/fixtures/skip-urls-with-tilde.expected.css
+++ b/test/fixtures/skip-urls-with-tilde.expected.css
@@ -1,0 +1,3 @@
+body {
+  background: url("~one"), url("~./two"), url("~@three"), url("~@four/qwe");
+}

--- a/test/type/copy.js
+++ b/test/type/copy.js
@@ -1,3 +1,8 @@
+compareFixtures(
+  'skip-urls-with-tilde',
+  'should skip URLs with tilde'
+);
+
 describe('copy without assetsPath', () => {
     const opts = {
         url: 'copy'

--- a/test/type/inline.js
+++ b/test/type/inline.js
@@ -24,6 +24,11 @@ describe('inline', () => {
         postcssOpts
     );
 
+    compareFixtures(
+      'skip-urls-with-tilde',
+      'should skip URLs with tilde'
+    );
+
     it('should inline url from dirname(from)', () => {
         const css = processedCss('fixtures/inline-from', opts, postcssOpts);
 

--- a/test/type/rebase.js
+++ b/test/type/rebase.js
@@ -86,4 +86,8 @@ describe('rebase', () => {
         opts,
         { from: 'test/fixtures/here', to: 'there' }
     );
+    compareFixtures(
+      'skip-urls-with-tilde',
+      'should skip URLs with tilde'
+    );
 });


### PR DESCRIPTION
Hi!
Webpack has cool feature to determine import from node_modules in stylesheets. Such imports are starting with tilde `~` and should not be processed by this plugin. This PR introduce ability to skip such imports. Corresponding tests are added.