### PR TITLE
fix(test): calling an asynchronous function without callback is deprecated

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -27,7 +27,7 @@ function compareFixtures(name, msg, opts, postcssOpts, plugin) {
               const expected = read(`fixtures/${name}.expected`);
 
             // handy thing: checkout actual in the *.actual.css file
-              fs.writeFile(`test/fixtures/${name}.actual.css`, actual);
+              fs.writeFileSync(`test/fixtures/${name}.actual.css`, actual);
 
               assert.equal(actual, expected);
           });


### PR DESCRIPTION
Hi @postcss

`fs` asynchronous functions now demand a callback. see https://nodejs.org/docs/latest-v8.x/api/fs.html#fs_fs_readfile_path_options_callback

This will make the tests Node@10 compatible :wink: 

<img width=693 src=https://user-images.githubusercontent.com/730511/43882145-f2a174c2-9bae-11e8-866e-3740fc940886.gif />
