### PR TITLE
Correct path resolution when to/from paths match

### DIFF
--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -57,7 +57,7 @@ const getAssetsPath = (baseDir, assetsPath, relative) =>
  * @returns {String}
  */
 const getTargetDir = (dir) =>
-    dir.from !== dir.to ? dir.to : process.cwd();
+    dir.to != null ? dir.to : process.cwd();
 
 /**
  * Stylesheet file path from decl

--- a/test/lib/paths.js
+++ b/test/lib/paths.js
@@ -74,6 +74,10 @@ describe('paths', () => {
         );
         assert.equal(
             paths.getTargetDir({ from: '/project', to: '/project' }),
+            '/project'
+        );
+        assert.equal(
+            paths.getTargetDir({ from: '/project' }),
             process.cwd()
         );
     });


### PR DESCRIPTION
If you want to run post-css on the following arrangement:

`postcss app/app.css -o app/app.bundle.css`

Postcss-url will then save the copied assets to `process.cwd()`, which in this case is `.`.  Not correct. It should copy the assets to `./app/${assetsPath}`.  

This fix makes it so the assets are correctly copied to the same folder (presumably inside of a `assetsPath`) when a `to` option exists.   Otherwise, use the old cwd() behavior. 

I'm not 100% sure what the intention of the original logic was, but it appeared to be guarding for when there was a missing `to` option.  This will still preserve the original behavior when `to` is !existy and use process.cwd().  Apologies if this understanding is incorrect.