### PR TITLE
Fix copy with no hash

### DIFF
--- a/src/type/copy.js
+++ b/src/type/copy.js
@@ -72,7 +72,7 @@ module.exports = function processCopy(asset, dir, options, decl, warn, result, a
 
             const assetRelativePath = options.useHash
                 ? getHashName(file, options.hashOptions)
-                : asset.relativePath;
+                : path.basename(file.path);
 
             const targetDir = getTargetDir(dir);
             const newAssetBaseDir = getAssetsPath(targetDir, options.assetsPath);


### PR DESCRIPTION
I realize this repo isn't touched often, but I think it's a great plugin. 

I came across an issue where if I used `copy` and `{ useHash: false }` it wouldn't copy the file. Took me longer to diagnose than it did to fix. 

Basically the existing code is referencing the full path to the existing file, unless it's replaced with a hashed filename. So I just replace the full path with the basename of the file.
