### PR TITLE
Update mime and xxhashjs dependencies to their newest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,9 +1458,9 @@
       }
     },
     "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2417,9 +2417,9 @@
       }
     },
     "xxhashjs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.1.tgz",
-      "integrity": "sha1-m76b6JYUKXbfo0wGGy0GjEPTDeA=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
       "requires": {
         "cuint": "^0.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "make-dir": "3.1.0",
-    "mime": "2.3.1",
+    "mime": "2.4.6",
     "minimatch": "3.0.4",
-    "xxhashjs": "0.2.1"
+    "xxhashjs": "0.2.2"
   },
   "devDependencies": {
     "chai": "4.1.2",


### PR DESCRIPTION
As a side effect of a8b6348c7ba2cbe3f76a001be5e8682384769ef7 some dependency versions were effectively downgraded.