### PR TITLE
Use the tilde operator for dependencies to allow for newer patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,9 +1458,9 @@
       }
     },
     "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "node": ">=10"
   },
   "dependencies": {
-    "make-dir": "3.1.0",
-    "mime": "2.4.6",
-    "minimatch": "3.0.4",
-    "xxhashjs": "0.2.2"
+    "make-dir": "~3.1.0",
+    "mime": "~2.4.6",
+    "minimatch": "~3.0.4",
+    "xxhashjs": "~0.2.2"
   },
   "devDependencies": {
     "chai": "4.1.2",


### PR DESCRIPTION
Using the [tilde operator](https://docs.npmjs.com/cli/v6/using-npm/semver#tilde-ranges-123-12-1), patch versions will be permitted but minor updates won't be.

Partially solves #145.

I think the tilde operator is a good compromise between the stability of exact versions and semver trust of dependencies. This is particularly relevant for `mime` which gets updated for new types occasingly. IMO it's not worth duplicating the library because of that.