### PR TITLE
Fix: upgrade mime to version 2.5

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 registry=http://registry.npmjs.org
-save-exact=true
+save-prefix='~'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "make-dir": "~3.1.0",
-    "mime": "~2.4.6",
+    "mime": "~2.5.2",
     "minimatch": "~3.0.4",
     "xxhashjs": "~0.2.2"
   },


### PR DESCRIPTION
This got accidentally reverted when merging #156.

I also changed the `save-prefix` to make sure the tilde is used when manipulating things via the CLI.