### PR TITLE
Use faster xxhash implementaion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,111 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@napi-rs/triples": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
+      "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
+    },
+    "@node-rs/helper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.2.1.tgz",
+      "integrity": "sha512-R5wEmm8nbuQU0YGGmYVjEc0OHtYsuXdpRG+Ut/3wZ9XAvQWyThN08bTh2cBJgoZxHQUPtvRfeQuxcAgLuiBISg==",
+      "requires": {
+        "@napi-rs/triples": "^1.0.3"
+      }
+    },
+    "@node-rs/xxhash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash/-/xxhash-1.0.0.tgz",
+      "integrity": "sha512-wVhbJT3QumfE7zlMLAZoAllaUufN5r3ia8vatKaqcG/Bau9SdFmcZpo8IuWDfSX+Jqyh9dViSRpUYChrVUvyFw==",
+      "requires": {
+        "@node-rs/helper": "^1.2.1",
+        "@node-rs/xxhash-android-arm64": "1.0.0",
+        "@node-rs/xxhash-darwin-arm64": "1.0.0",
+        "@node-rs/xxhash-darwin-x64": "1.0.0",
+        "@node-rs/xxhash-freebsd-x64": "1.0.0",
+        "@node-rs/xxhash-linux-arm-gnueabihf": "1.0.0",
+        "@node-rs/xxhash-linux-arm64-gnu": "1.0.0",
+        "@node-rs/xxhash-linux-arm64-musl": "1.0.0",
+        "@node-rs/xxhash-linux-x64-gnu": "1.0.0",
+        "@node-rs/xxhash-linux-x64-musl": "1.0.0",
+        "@node-rs/xxhash-win32-arm64-msvc": "1.0.0",
+        "@node-rs/xxhash-win32-ia32-msvc": "1.0.0",
+        "@node-rs/xxhash-win32-x64-msvc": "1.0.0"
+      }
+    },
+    "@node-rs/xxhash-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-android-arm64/-/xxhash-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-42kUl4BftrywIz5ce8vjRop9/+W+0thwOL8Q0xFvOnlKIrFBprbF0qGTC67p+GJVGIJFU8SD8ykVF0aN7SpGUA==",
+      "optional": true
+    },
+    "@node-rs/xxhash-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-darwin-arm64/-/xxhash-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-MMXib4NbxQ3nIMu7d+jQsvhx/afO3GW5FnCOZYKxRgvwmu/s0emu3/nbDIV4d19gVrZE76o9zbAcgGkbZ5p02g==",
+      "optional": true
+    },
+    "@node-rs/xxhash-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-darwin-x64/-/xxhash-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-aBOj3UwGTnLRfutS/70GkAdZTBtqNputxs9IUXvmHcXApqM750NNTtp/bqUhebKf9Lp9VjiR3Y1T2/YPvTYZjw==",
+      "optional": true
+    },
+    "@node-rs/xxhash-freebsd-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-freebsd-x64/-/xxhash-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-RucPV0CBFZv4TTac4YhI4XFCPwPKPd8kePzy+YBCY+lt341A09tIIE60GDX0LExpTHKEp/+1375SE/x8QtJj4Q==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-arm-gnueabihf/-/xxhash-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-pLTgTyQr1C9HZBoEbAPuNebeylWPGMa+gPilqpstg/aRmHleasPWBjURbX8UMK9iGADeS0OhV/p3XueQ6369MQ==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-arm64-gnu/-/xxhash-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-o4UdKnTe0x6n7/3vVpIORF9p7M9R8latdvQ/fjOgCou80peSboC9AZprsqUGPiEZ7YG5+ZphMF4S8+TEZoaLSg==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-arm64-musl/-/xxhash-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-AjGWZiCkoqaS3SYXdMr9470bVj9QtzZND2amYHWcj6Thi0fl3jiZ1n7gMmzEYuUxSfeNWqWMY5u0G82sbmsi9Q==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-x64-gnu/-/xxhash-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-zJpQTjDrSz//IZ9YoNOoOEz2XnFIMprn4KKCvyEBkx6r16kAvzzTpynqFOcQvXWSErW4PAf8QkgY4hv+R0S89Q==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-x64-musl/-/xxhash-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-tJu5ubJ/ljmFaMuQBjSs7z8UHhAh9fK6V9I58wHETjU8Q+8r2IYarwsQ4e4fmochDjz3/R8xm02WMHR7s5I/vw==",
+      "optional": true
+    },
+    "@node-rs/xxhash-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-win32-arm64-msvc/-/xxhash-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-gAPGspa5BIZ/6SQMgCzhSEOfgOgTaNpGf6oFFo+Q05AOkPUwkWS+BOpuYhoopFWUIr23Q7Ej2Ne8MYpQknC3og==",
+      "optional": true
+    },
+    "@node-rs/xxhash-win32-ia32-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-win32-ia32-msvc/-/xxhash-win32-ia32-msvc-1.0.0.tgz",
+      "integrity": "sha512-RHEf9Q5kpjH6f+qH5BQdQmwuBV+VG0kWG5xCcsExJ9D6tn899XSZxRPeJNS8AgJvr+mz1nfJzEx8DR2ZzWP+ZQ==",
+      "optional": true
+    },
+    "@node-rs/xxhash-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-win32-x64-msvc/-/xxhash-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-xT5Xu5mGfgEGoeNRMuqkyM7KdZEL0H4e4RxF+k/B67U/0K0t5fAs2EVH2qDCG2McgbND85G4BMUzdyaMuEuaSQ==",
+      "optional": true
+    },
     "@octokit/auth-token": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.3.tgz",
@@ -551,11 +656,6 @@
         "lru-cache": "^4.0.0",
         "which": "^1.2.8"
       }
-    },
-    "cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
     },
     "debug": {
       "version": "4.1.1",
@@ -2414,14 +2514,6 @@
         "pify": "^2.2.0",
         "user-home": "^2.0.0",
         "xdg-basedir": "^2.0.0"
-      }
-    },
-    "xxhashjs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
-      "requires": {
-        "cuint": "^0.2.2"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10.20"
   },
   "dependencies": {
+    "@node-rs/xxhash": "~1.0.0",
     "make-dir": "~3.1.0",
     "mime": "~2.5.2",
-    "minimatch": "~3.0.4",
-    "xxhashjs": "~0.2.2"
+    "minimatch": "~3.0.4"
   },
   "devDependencies": {
     "chai": "4.1.2",

--- a/src/lib/hash.js
+++ b/src/lib/hash.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const crypto = require('crypto');
-const xxh = require('xxhashjs');
+const { xxh32, xxh64 } = require('@node-rs/xxhash');
 const HEXBASE = 16;
 
 const defaultHashOptions = {
@@ -11,13 +11,9 @@ const defaultHashOptions = {
 };
 
 const getxxhash = (content, options) => {
-    const hashFunc = options.method === 'xxhash32' ? xxh.h32 : xxh.h64;
-    const seed = 0;
+    const hashFunc = options.method === 'xxhash32' ? xxh32 : xxh64;
 
-    return hashFunc(seed)
-        .update(content)
-        .digest()
-        .toString(HEXBASE);
+    return hashFunc(content).toString(HEXBASE);
 };
 
 const getHash = (content, options) => {


### PR DESCRIPTION
[`@node-rs/xxhash`](https://github.com/napi-rs/node-rs/tree/main/packages/xxhash) is significant faster than `xxhashjs`:

```
@node-rs/xxhash h32 x 18,847 ops/sec ±3.81% (81 runs sampled)
xxhashjs h32 x 1,035 ops/sec ±11.04% (68 runs sampled)
xxh32 bench suite: Fastest is @node-rs/xxhash h32

@node-rs/xxhash 64 x 43,532 ops/sec ±1.33% (88 runs sampled)
xxhashjs h64 x 47.52 ops/sec ±3.20% (62 runs sampled)
xxh64 bench suite: Fastest is @node-rs/xxhash 64
```

`xxh32` is **18x** faster than `xxhashjs` and `xxh64` is **916x** faster than `xxhashjs`.